### PR TITLE
Layering additional complexity onto the "multipage" scenario

### DIFF
--- a/examples/multipage/src/app.rs
+++ b/examples/multipage/src/app.rs
@@ -3,6 +3,7 @@ use mogwai::prelude::*;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Route {
+    Game,
     Home,
     NotFound,
 }
@@ -16,6 +17,7 @@ impl From<Route> for View<HtmlElement> {
 impl From<Route> for ViewBuilder<HtmlElement> {
     fn from(route: Route) -> Self {
         match route {
+            Route::Game => routes::game("foo".into()),
             Route::Home => routes::home(),
             Route::NotFound => routes::not_found(),
         }
@@ -74,12 +76,36 @@ impl Component for App {
             <div class="root">
                 <p>{("0 times", rx_text)}</p>
                 <nav>
-                    <button on:click=tx.contra_map(|_| Route::Home)>
+                    <a
+                        href="/"
+                        style="margin-right: 15px;"
+                        on:click=tx.contra_map(|e: &Event| {
+                            e.prevent_default();
+                            Route::Home
+                        })
+                    >
                         "Home"
-                    </button>
-                    <button on:click=tx.contra_map(|_| Route::NotFound)>
+                    </a>
+                    <a
+                        href="/game"
+                        style="margin-right: 15px;"
+                        on:click=tx.contra_map(|e: &Event| {
+                            e.prevent_default();
+                            Route::Game
+                        })
+                    >
+                        "Game"
+                    </a>
+                    <a
+                        href="/404"
+                        style="margin-right: 15px;"
+                        on:click=tx.contra_map(|e: &Event| {
+                            e.prevent_default();
+                            Route::NotFound
+                        })
+                    >
                         "Not Found"
-                    </button>
+                    </a>
                 </nav>
                 {contents}
             </div>

--- a/examples/multipage/src/app.rs
+++ b/examples/multipage/src/app.rs
@@ -72,6 +72,7 @@ impl Component for App {
         contents.replaces = vec![rx_main];
         builder! {
             <div class="root">
+                <p>{("0 times", rx_text)}</p>
                 <nav>
                     <button on:click=tx.contra_map(|_| Route::Home)>
                         "Home"
@@ -80,7 +81,6 @@ impl Component for App {
                         "Not Found"
                     </button>
                 </nav>
-                <p>{("0 times", rx_text)}</p>
                 {contents}
             </div>
         }

--- a/examples/multipage/src/components/game.rs
+++ b/examples/multipage/src/components/game.rs
@@ -1,0 +1,98 @@
+use mogwai::prelude::*;
+use std::convert::TryInto;
+
+pub enum Update {
+    Cell {
+        row: u16,
+        column: u16,
+        value: String,
+    },
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct CellInteract {
+    pub row: u16,
+    pub column: u16,
+    pub flag: bool,
+}
+
+fn panicky_u16(value: usize) -> u16 {
+    value.try_into().unwrap()
+}
+
+#[allow(unused_braces)]
+fn board_cell(
+    coords: (u16, u16),
+    tx: Transmitter<CellInteract>,
+    rx: Receiver<Update>,
+) -> ViewBuilder<HtmlElement> {
+    let (col, row) = coords;
+    let rx_text = rx.branch_filter_map(move |update| match update {
+        Update::Cell {
+            row: y,
+            column: x,
+            value,
+        } if *x == col && *y == row => Some(value.to_owned()),
+        _ => None,
+    });
+    builder! {
+        <td
+            valign="middle"
+            align="center"
+            style="height: 50px; width: 50px; border: 1px solid black;"
+            on:click=tx.contra_map(move |event: &Event| CellInteract {
+                row,
+                column: col,
+                // TODO: Check if `MouseEvent` has modifier keys held (alt, ctrl)
+                flag: event.bubbles(),
+            })
+        >
+            // Cells initialize to empty but may update if revealed or clicked
+            {(" ", rx_text)}
+        </td>
+    }
+}
+
+fn board_row<'b>(
+    row: u16,
+    cells: Vec<&'b str>,
+    tx: Transmitter<CellInteract>,
+    rx: Receiver<Update>,
+) -> ViewBuilder<HtmlElement> {
+    let children = cells
+        .into_iter()
+        .enumerate()
+        .map(|(col, _)| board_cell((panicky_u16(col), row), tx.clone(), rx.branch()));
+    let mut tr = ViewBuilder {
+        element: Some("tr".to_owned()),
+        ..ViewBuilder::default()
+    };
+    for child in children {
+        tr.with(child);
+    }
+    tr
+}
+
+#[allow(unused_braces)]
+pub fn board<'a>(
+    cells: Vec<Vec<&'a str>>,
+    tx: Transmitter<CellInteract>,
+    rx: Receiver<Update>,
+) -> ViewBuilder<HtmlElement> {
+    let children = cells
+        .into_iter()
+        .enumerate()
+        .map(|(row, cells)| board_row(panicky_u16(row), cells, tx.clone(), rx.branch()));
+    let mut tbody: ViewBuilder<HtmlElement> = ViewBuilder {
+        element: Some("tbody".to_owned()),
+        ..ViewBuilder::default()
+    };
+    for child in children {
+        tbody.with(child);
+    }
+    builder! {
+        <table>
+            {tbody}
+        </table>
+    }
+}

--- a/examples/multipage/src/components/mod.rs
+++ b/examples/multipage/src/components/mod.rs
@@ -1,0 +1,1 @@
+pub mod game;

--- a/examples/multipage/src/lib.rs
+++ b/examples/multipage/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+mod components;
 mod routes;
 
 use crate::app::App;

--- a/examples/multipage/src/lib.rs
+++ b/examples/multipage/src/lib.rs
@@ -1,6 +1,7 @@
 mod app;
 mod routes;
 
+use crate::app::App;
 use log::{trace, Level};
 use mogwai::prelude::*;
 use std::panic;
@@ -24,11 +25,12 @@ pub fn main() -> Result<(), JsValue> {
     }
 
     // Create our app's view by hydrating a gizmo from an initial state
-    let app: Gizmo<app::App> = Gizmo::new(app::App::new());
+    let root = App::new();
+    let root_app: Gizmo<App> = Gizmo::new(root);
 
     // Hand the app's view ownership to the window so it never
     // goes out of scope
-    app.run()
+    root_app.run()
 }
 
 #[cfg(test)]

--- a/examples/multipage/src/routes/mod.rs
+++ b/examples/multipage/src/routes/mod.rs
@@ -41,13 +41,46 @@ fn new_button_view(tx_click: Transmitter<Event>) -> ViewBuilder<HtmlElement> {
     button
 }
 
+fn stars() -> ViewBuilder<HtmlElement> {
+    builder! {
+        <div className="three-stars">
+            <span>"★"</span>
+            <span>"★"</span>
+            <span>"★"</span>
+        </div>
+    }
+}
+
+#[allow(unused_braces)]
+fn star_title(rx_org: Receiver<String>) -> ViewBuilder<HtmlElement> {
+    let org_name = rx_org.branch_map(|org| format!("from {}?", org));
+    builder! {
+        <div class="title-component uppercase">
+            {stars()}
+            <div class="title-component__description">
+                <span class="strike-preamble">"Did contributions come"</span>
+                <span class="strike-out">{("from you?", org_name)}</span>
+            </div>
+        </div>
+    }
+}
+
 #[allow(unused_braces)]
 pub fn home() -> ViewBuilder<HtmlElement> {
     // Create a transmitter to send button clicks into.
     let tx_click = Transmitter::new();
+    let rx_org = Receiver::new();
     builder! {
-        <main>
-            {new_button_view(tx_click)}
+        <main class="container">
+            <div class="overlay">
+                "This site is only supported in portrait mode."
+            </div>
+            <div class="page-one">
+                <div class="section-block">
+                    {star_title(rx_org)}
+                    {new_button_view(tx_click)}
+                </div>
+            </div>
         </main>
     }
 }

--- a/examples/multipage/src/routes/mod.rs
+++ b/examples/multipage/src/routes/mod.rs
@@ -1,3 +1,4 @@
+use crate::components::game::{board, CellInteract, Update};
 use mogwai::prelude::*;
 
 /// Defines a button that changes its text every time it is clicked.
@@ -62,6 +63,29 @@ fn star_title(rx_org: Receiver<String>) -> ViewBuilder<HtmlElement> {
                 <span class="strike-out">{("from you?", org_name)}</span>
             </div>
         </div>
+    }
+}
+
+#[allow(unused_braces)]
+pub fn game(id: String) -> ViewBuilder<HtmlElement> {
+    // Create a transmitter to send button clicks into.
+    let tx_cells: Transmitter<CellInteract> = Transmitter::new();
+    let rx_cell_updates = Receiver::new();
+    tx_cells.wire_map(&rx_cell_updates, |e| Update::Cell {
+        column: e.column,
+        row: e.row,
+        value: "x".into(),
+    });
+    let initial_board = vec![vec![" ", " "], vec![" ", " "]];
+    builder! {
+        <main class="container">
+            <div class="overlay">
+                "This site is only supported in portrait mode."
+            </div>
+            <div class="game-board" data-game-id=id>
+                {board(initial_board, tx_cells, rx_cell_updates)}
+            </div>
+        </main>
     }
 }
 


### PR DESCRIPTION
Add a third page that does more than render parts of other examples. Try to build a simple version of a minesweeper like user interface with rows and cells whose state is updated by asynchronous API requests.